### PR TITLE
fix: add null checks for noise protocol initialization and key handling

### DIFF
--- a/libp2p/security/noise/io.py
+++ b/libp2p/security/noise/io.py
@@ -50,12 +50,12 @@ class BaseNoiseMsgReadWriter(EncryptedMsgReadWriter):
         self.read_writer = NoisePacketReadWriter(cast(ReadWriteCloser, conn))
         self.noise_state = noise_state
 
-    async def write_msg(self, data: bytes, prefix_encoded: bool = False) -> None:
-        data_encrypted = self.encrypt(data)
+    async def write_msg(self, msg: bytes, prefix_encoded: bool = False) -> None:
+        data_encrypted = self.encrypt(msg)
         if prefix_encoded:
-            await self.read_writer.write_msg(self.prefix + data_encrypted)
-        else:
-            await self.read_writer.write_msg(data_encrypted)
+            # Manually add the prefix if needed
+            data_encrypted = self.prefix + data_encrypted
+        await self.read_writer.write_msg(data_encrypted)
 
     async def read_msg(self, prefix_encoded: bool = False) -> bytes:
         noise_msg_encrypted = await self.read_writer.read_msg()
@@ -70,15 +70,18 @@ class BaseNoiseMsgReadWriter(EncryptedMsgReadWriter):
     def get_remote_address(self) -> Optional[tuple[str, int]]:
         # Delegate to the underlying connection if possible
         if hasattr(self.read_writer, "read_write_closer") and hasattr(
-            self.read_writer.read_write_closer, "get_remote_address"
+            cast(NoisePacketReadWriter, self.read_writer).read_write_closer,
+            "get_remote_address",
         ):
-            return self.read_writer.read_write_closer.get_remote_address()
+            return cast(
+                NoisePacketReadWriter, self.read_writer
+            ).read_write_closer.get_remote_address()
         return None
 
 
 class NoiseHandshakeReadWriter(BaseNoiseMsgReadWriter):
     def encrypt(self, data: bytes) -> bytes:
-        return self.noise_state.write_message(data)
+        return bytes(self.noise_state.write_message(data))
 
     def decrypt(self, data: bytes) -> bytes:
         return bytes(self.noise_state.read_message(data))

--- a/libp2p/security/noise/patterns.py
+++ b/libp2p/security/noise/patterns.py
@@ -70,6 +70,8 @@ class BasePattern(IPattern):
         noise_state.set_keypair_from_private_bytes(
             NoiseKeypairEnum.STATIC, self.noise_static_key.to_bytes()
         )
+        if noise_state.noise_protocol is None:
+            raise NoiseStateError("noise_protocol is not initialized")
         return noise_state
 
     def make_handshake_payload(self) -> NoiseHandshakePayload:
@@ -97,6 +99,8 @@ class PatternXX(BasePattern):
         noise_state = self.create_noise_state()
         noise_state.set_as_responder()
         noise_state.start_handshake()
+        if noise_state.noise_protocol is None:
+            raise NoiseStateError("noise_protocol is not initialized")
         handshake_state = noise_state.noise_protocol.handshake_state
         read_writer = NoiseHandshakeReadWriter(conn, noise_state)
 
@@ -146,6 +150,8 @@ class PatternXX(BasePattern):
         read_writer = NoiseHandshakeReadWriter(conn, noise_state)
         noise_state.set_as_initiator()
         noise_state.start_handshake()
+        if noise_state.noise_protocol is None:
+            raise NoiseStateError("noise_protocol is not initialized")
         handshake_state = noise_state.noise_protocol.handshake_state
 
         # Send msg#1, which is *not* encrypted.
@@ -196,6 +202,8 @@ class PatternXX(BasePattern):
     @staticmethod
     def _get_pubkey_from_noise_keypair(key_pair: NoiseKeyPair) -> PublicKey:
         # Use `Ed25519PublicKey` since 25519 is used in our pattern.
+        if key_pair.public is None:
+            raise NoiseStateError("public key is not initialized")
         raw_bytes = key_pair.public.public_bytes(
             serialization.Encoding.Raw, serialization.PublicFormat.Raw
         )


### PR DESCRIPTION
## What was wrong?

Issue #618

The noise protocol implementation had missing null checks for initialization and key handling, which could lead to runtime errors when the protocol was not properly initialized or when keys were not set.

## How was it fixed?

Added null checks in the noise protocol implementation to ensure proper initialization and key handling:

1. Added null checks in `NoiseConnection` initialization
2. Added null checks for key handling in `NoiseState`
3. Improved type safety by removing `Any` type aliases
4. Added proper error handling for uninitialized states

### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![A cute otter holding hands with another otter while floating on water](https://images.unsplash.com/photo-1516934024742-b461fba47600?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80)