### PR TITLE
fix:corrected argument-errors in peerId and Multiaddr in peer tests

### DIFF
--- a/tests/core/peer/test_addrbook.py
+++ b/tests/core/peer/test_addrbook.py
@@ -1,5 +1,9 @@
 import pytest
+from multiaddr import (
+    Multiaddr,
+)
 
+from libp2p.peer.id import ID
 from libp2p.peer.peerstore import (
     PeerStore,
     PeerStoreError,
@@ -11,51 +15,72 @@ from libp2p.peer.peerstore import (
 def test_addrs_empty():
     with pytest.raises(PeerStoreError):
         store = PeerStore()
-        val = store.addrs("peer")
+        val = store.addrs(ID(b"peer"))
         assert not val
 
 
 def test_add_addr_single():
     store = PeerStore()
-    store.add_addr("peer1", "/foo", 10)
-    store.add_addr("peer1", "/bar", 10)
-    store.add_addr("peer2", "/baz", 10)
+    store.add_addr(ID(b"peer1"), Multiaddr("/ip4/127.0.0.1/tcp/4001"), 10)
+    store.add_addr(ID(b"peer1"), Multiaddr("/ip4/127.0.0.1/tcp/4002"), 10)
+    store.add_addr(ID(b"peer2"), Multiaddr("/ip4/127.0.0.1/tcp/4003"), 10)
 
-    assert store.addrs("peer1") == ["/foo", "/bar"]
-    assert store.addrs("peer2") == ["/baz"]
+    assert store.addrs(ID(b"peer1")) == [
+        Multiaddr("/ip4/127.0.0.1/tcp/4001"),
+        Multiaddr("/ip4/127.0.0.1/tcp/4002"),
+    ]
+    assert store.addrs(ID(b"peer2")) == [Multiaddr("/ip4/127.0.0.1/tcp/4003")]
 
 
 def test_add_addrs_multiple():
     store = PeerStore()
-    store.add_addrs("peer1", ["/foo1", "/bar1"], 10)
-    store.add_addrs("peer2", ["/foo2"], 10)
+    store.add_addrs(
+        ID(b"peer1"),
+        [Multiaddr("/ip4/127.0.0.1/tcp/40011"), Multiaddr("/ip4/127.0.0.1/tcp/40021")],
+        10,
+    )
+    store.add_addrs(ID(b"peer2"), [Multiaddr("/ip4/127.0.0.1/tcp/40012")], 10)
 
-    assert store.addrs("peer1") == ["/foo1", "/bar1"]
-    assert store.addrs("peer2") == ["/foo2"]
+    assert store.addrs(ID(b"peer1")) == [
+        Multiaddr("/ip4/127.0.0.1/tcp/40011"),
+        Multiaddr("/ip4/127.0.0.1/tcp/40021"),
+    ]
+    assert store.addrs(ID(b"peer2")) == [Multiaddr("/ip4/127.0.0.1/tcp/40012")]
 
 
 def test_clear_addrs():
     store = PeerStore()
-    store.add_addrs("peer1", ["/foo1", "/bar1"], 10)
-    store.add_addrs("peer2", ["/foo2"], 10)
-    store.clear_addrs("peer1")
+    store.add_addrs(
+        ID(b"peer1"),
+        [Multiaddr("/ip4/127.0.0.1/tcp/40011"), Multiaddr("/ip4/127.0.0.1/tcp/40021")],
+        10,
+    )
+    store.add_addrs(ID(b"peer2"), [Multiaddr("/ip4/127.0.0.1/tcp/40012")], 10)
+    store.clear_addrs(ID(b"peer1"))
 
-    assert store.addrs("peer1") == []
-    assert store.addrs("peer2") == ["/foo2"]
+    assert store.addrs(ID(b"peer1")) == []
+    assert store.addrs(ID(b"peer2")) == [Multiaddr("/ip4/127.0.0.1/tcp/40012")]
 
-    store.add_addrs("peer1", ["/foo1", "/bar1"], 10)
+    store.add_addrs(
+        ID(b"peer1"),
+        [Multiaddr("/ip4/127.0.0.1/tcp/40011"), Multiaddr("/ip4/127.0.0.1/tcp/40021")],
+        10,
+    )
 
-    assert store.addrs("peer1") == ["/foo1", "/bar1"]
+    assert store.addrs(ID(b"peer1")) == [
+        Multiaddr("/ip4/127.0.0.1/tcp/40011"),
+        Multiaddr("/ip4/127.0.0.1/tcp/40021"),
+    ]
 
 
 def test_peers_with_addrs():
     store = PeerStore()
-    store.add_addrs("peer1", [], 10)
-    store.add_addrs("peer2", ["/foo"], 10)
-    store.add_addrs("peer3", ["/bar"], 10)
+    store.add_addrs(ID(b"peer1"), [], 10)
+    store.add_addrs(ID(b"peer2"), [Multiaddr("/ip4/127.0.0.1/tcp/4001")], 10)
+    store.add_addrs(ID(b"peer3"), [Multiaddr("/ip4/127.0.0.1/tcp/4002")], 10)
 
-    assert set(store.peers_with_addrs()) == {"peer2", "peer3"}
+    assert set(store.peers_with_addrs()) == {ID(b"peer2"), ID(b"peer3")}
 
-    store.clear_addrs("peer2")
+    store.clear_addrs(ID(b"peer2"))
 
-    assert set(store.peers_with_addrs()) == {"peer3"}
+    assert set(store.peers_with_addrs()) == {ID(b"peer3")}

--- a/tests/core/peer/test_peermetadata.py
+++ b/tests/core/peer/test_peermetadata.py
@@ -1,5 +1,6 @@
 import pytest
 
+from libp2p.peer.id import ID
 from libp2p.peer.peerstore import (
     PeerStore,
     PeerStoreError,
@@ -11,36 +12,36 @@ from libp2p.peer.peerstore import (
 def test_get_empty():
     with pytest.raises(PeerStoreError):
         store = PeerStore()
-        val = store.get("peer", "key")
+        val = store.get(ID(b"peer"), "key")
         assert not val
 
 
 def test_put_get_simple():
     store = PeerStore()
-    store.put("peer", "key", "val")
-    assert store.get("peer", "key") == "val"
+    store.put(ID(b"peer"), "key", "val")
+    assert store.get(ID(b"peer"), "key") == "val"
 
 
 def test_put_get_update():
     store = PeerStore()
-    store.put("peer", "key1", "val1")
-    store.put("peer", "key2", "val2")
-    store.put("peer", "key2", "new val2")
+    store.put(ID(b"peer"), "key1", "val1")
+    store.put(ID(b"peer"), "key2", "val2")
+    store.put(ID(b"peer"), "key2", "new val2")
 
-    assert store.get("peer", "key1") == "val1"
-    assert store.get("peer", "key2") == "new val2"
+    assert store.get(ID(b"peer"), "key1") == "val1"
+    assert store.get(ID(b"peer"), "key2") == "new val2"
 
 
 def test_put_get_two_peers():
     store = PeerStore()
-    store.put("peer1", "key1", "val1")
-    store.put("peer2", "key1", "val1 prime")
+    store.put(ID(b"peer1"), "key1", "val1")
+    store.put(ID(b"peer2"), "key1", "val1 prime")
 
-    assert store.get("peer1", "key1") == "val1"
-    assert store.get("peer2", "key1") == "val1 prime"
+    assert store.get(ID(b"peer1"), "key1") == "val1"
+    assert store.get(ID(b"peer2"), "key1") == "val1 prime"
 
     # Try update
-    store.put("peer2", "key1", "new val1")
+    store.put(ID(b"peer2"), "key1", "new val1")
 
-    assert store.get("peer1", "key1") == "val1"
-    assert store.get("peer2", "key1") == "new val1"
+    assert store.get(ID(b"peer1"), "key1") == "val1"
+    assert store.get(ID(b"peer2"), "key1") == "new val1"

--- a/tests/core/peer/test_peerstore.py
+++ b/tests/core/peer/test_peerstore.py
@@ -1,5 +1,7 @@
 import pytest
+from multiaddr import Multiaddr
 
+from libp2p.peer.id import ID
 from libp2p.peer.peerstore import (
     PeerStore,
     PeerStoreError,
@@ -11,52 +13,52 @@ from libp2p.peer.peerstore import (
 def test_peer_info_empty():
     store = PeerStore()
     with pytest.raises(PeerStoreError):
-        store.peer_info("peer")
+        store.peer_info(ID(b"peer"))
 
 
 def test_peer_info_basic():
     store = PeerStore()
-    store.add_addr("peer", "/foo", 10)
-    info = store.peer_info("peer")
+    store.add_addr(ID(b"peer"), Multiaddr("/ip4/127.0.0.1/tcp/4001"), 10)
+    info = store.peer_info(ID(b"peer"))
 
-    assert info.peer_id == "peer"
-    assert info.addrs == ["/foo"]
+    assert info.peer_id == ID(b"peer")
+    assert info.addrs == [Multiaddr("/ip4/127.0.0.1/tcp/4001")]
 
 
 def test_add_get_protocols_basic():
     store = PeerStore()
-    store.add_protocols("peer1", ["p1", "p2"])
-    store.add_protocols("peer2", ["p3"])
+    store.add_protocols(ID(b"peer1"), ["p1", "p2"])
+    store.add_protocols(ID(b"peer2"), ["p3"])
 
-    assert set(store.get_protocols("peer1")) == {"p1", "p2"}
-    assert set(store.get_protocols("peer2")) == {"p3"}
+    assert set(store.get_protocols(ID(b"peer1"))) == {"p1", "p2"}
+    assert set(store.get_protocols(ID(b"peer2"))) == {"p3"}
 
 
 def test_add_get_protocols_extend():
     store = PeerStore()
-    store.add_protocols("peer1", ["p1", "p2"])
-    store.add_protocols("peer1", ["p3"])
+    store.add_protocols(ID(b"peer1"), ["p1", "p2"])
+    store.add_protocols(ID(b"peer1"), ["p3"])
 
-    assert set(store.get_protocols("peer1")) == {"p1", "p2", "p3"}
+    assert set(store.get_protocols(ID(b"peer1"))) == {"p1", "p2", "p3"}
 
 
 def test_set_protocols():
     store = PeerStore()
-    store.add_protocols("peer1", ["p1", "p2"])
-    store.add_protocols("peer2", ["p3"])
+    store.add_protocols(ID(b"peer1"), ["p1", "p2"])
+    store.add_protocols(ID(b"peer2"), ["p3"])
 
-    store.set_protocols("peer1", ["p4"])
-    store.set_protocols("peer2", [])
+    store.set_protocols(ID(b"peer1"), ["p4"])
+    store.set_protocols(ID(b"peer2"), [])
 
-    assert set(store.get_protocols("peer1")) == {"p4"}
-    assert set(store.get_protocols("peer2")) == set()
+    assert set(store.get_protocols(ID(b"peer1"))) == {"p4"}
+    assert set(store.get_protocols(ID(b"peer2"))) == set()
 
 
 # Test with methods from other Peer interfaces.
 def test_peers():
     store = PeerStore()
-    store.add_protocols("peer1", [])
-    store.put("peer2", "key", "val")
-    store.add_addr("peer3", "/foo", 10)
+    store.add_protocols(ID(b"peer1"), [])
+    store.put(ID(b"peer2"), "key", "val")
+    store.add_addr(ID(b"peer3"), Multiaddr("/ip4/127.0.0.1/tcp/4001"), 10)
 
-    assert set(store.peer_ids()) == {"peer1", "peer2", "peer3"}
+    assert set(store.peer_ids()) == {ID(b"peer1"), ID(b"peer2"), ID(b"peer3")}


### PR DESCRIPTION
## What was wrong?
Issue: https://github.com/libp2p/py-libp2p/pull/618
The test cases in `test_addrbook.py` , `test_peerstore.py` and `test_peermetadata.py` used direct-strings in functions where the arguments where of type ID,leading to type-error.Same goes for multi-addresses ,along with strings having incorrect protocol which were raising exceptions in Multiaddr class.
## How was it fixed?
### Updates to Peer Identifier and Address Handling:
* **Use of `ID` for Peer Identifiers**:
  - Replaced string-based peer identifiers with instances of the `ID` class in all test cases to ensure type safety and alignment with the `libp2p` library.
  
* **Use of `Multiaddr` for Addresses**:
  - Replaced string-based addresses with instances of the `Multiaddr` class in test cases, ensuring consistency with the expected address format. 
  - Also changed invalid protocol strings like `/foo`,`/bar`,etc  with dummy multi-addresses having valid protocols.


### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal image](https://compote.slate.com/images/73f0857e-2a1a-4fea-b97a-bd4c241c01f5.jpg)
