### PR TITLE
Fix type checks for pubsub module-tests

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -10,6 +10,8 @@ from collections.abc import (
 )
 from typing import (
     TYPE_CHECKING,
+    Dict,
+    Set,
     Any,
     AsyncContextManager,
 )
@@ -1826,6 +1828,11 @@ class IPubsubRouter(ABC):
 
     """
 
+    mesh: dict[str, set[ID]]
+    fanout: dict[str, set[ID]]
+    peer_protocol: dict[ID, TProtocol]
+    degree: int
+    
     @abstractmethod
     def get_protocols(self) -> list[TProtocol]:
         """
@@ -1864,6 +1871,31 @@ class IPubsubRouter(ABC):
 
         """
 
+    @abstractmethod
+    async def emit_graft(self, topic:str, id:ID) -> None:
+        """
+        Parameters
+        ----------
+        topic : str
+        The topic to emit.
+        id : ID
+            The identifier of the peer
+
+        """
+        
+    @abstractmethod
+    async def emit_prune(self, topic:str, id:ID) -> None:
+        """
+        Emit prune message to peer
+        Parameters
+        ----------
+        topic : str
+        The topic to emit to prune.
+        id : ID
+            The identifier of the peer
+
+        """
+        
     @abstractmethod
     def remove_peer(self, peer_id: ID) -> None:
         """
@@ -1927,8 +1959,29 @@ class IPubsubRouter(ABC):
             The topic to leave.
 
         """
+    def gossip_heartbeat(self) -> dict[ID, dict[str, list[str]]]:
+        """
+        Retrieve the list of peers to gossip heartbeat.
 
+        Returns
+        -------
+        dict[ID, dict[str, list[str]]]
+            A list of all peers to gossip heartbeat.
 
+        """
+    def mesh_heartbeat(self) -> tuple[dict[ID, list[str]], dict[ID, list[str]]]:
+        """
+        Retrieve the list of peers to graft and prune.
+
+        Returns
+        -------
+        dict[ID, list[str]]
+            A list of all peers to graft.
+        dict[ID, list[str]]
+            A list of all peers to prune.
+
+        """
+        
 class IPubsub(ServiceAPI):
     """
     Interface for the pubsub system.


### PR DESCRIPTION
## What was wrong?

Issue # https://github.com/libp2p/py-libp2p/pull/618

## How was it fixed?
Added undefined attributes and functions to abc.py


### To-Do

Type-fixing for some pubsub tests is still left. Will add them to this PR.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.etsystatic.com/27171676/r/il/eedb08/5303109239/il_570xN.5303109239_4o61.jpg
)
