### PR TITLE
Fix failing tests for type-fixed test/pubsub

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -1869,32 +1869,6 @@ class IPubsubRouter(ABC):
 
         """
 
-    async def emit_graft(self, topic: str, id: ID) -> None:
-        """
-        Parameters
-        ----------
-        topic : str
-            The topic to emit.
-        id : ID
-            The identifier of the peer
-
-        """
-        pass
-
-    async def emit_prune(self, topic: str, id: ID) -> None:
-        """
-        Emit prune message to peer
-
-        Parameters
-        ----------
-        topic : str
-            The topic to emit to prune.
-        id : ID
-            The identifier of the peer
-
-        """
-        pass
-
     @abstractmethod
     def remove_peer(self, peer_id: ID) -> None:
         """
@@ -1958,32 +1932,6 @@ class IPubsubRouter(ABC):
             The topic to leave.
 
         """
-
-    def gossip_heartbeat(self) -> dict[ID, dict[str, list[str]]]:
-        """
-        Retrieve the list of peers to gossip heartbeat.
-
-        Returns
-        -------
-        dict[ID, dict[str, list[str]]]
-            A list of all peers to gossip heartbeat.
-
-        """
-        pass
-
-    def mesh_heartbeat(self) -> tuple[dict[ID, list[str]], dict[ID, list[str]]]:
-        """
-        Retrieve the list of peers to graft and prune.
-
-        Returns
-        -------
-        dict[ID, list[str]]
-            A list of all peers to graft.
-        dict[ID, list[str]]
-            A list of all peers to prune.
-
-        """
-        pass
 
 
 class IPubsub(ServiceAPI):


### PR DESCRIPTION
## What was wrong?

Some tests were failing while fixing type for tests/pubsub

## How was it fixed?
There were some abstractmethods in the `IPubsubRouter` class which were not implemented in some of the instances of that class. So, made them non-abstract and defined a basic definition in the base class, which are overridden on implementing that class's methods if needed. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.etsystatic.com/27171676/r/il/eedb08/5303109239/il_570xN.5303109239_4o61.jpg)
