### PR TITLE
Fix type errors to not trigger pre-commit hooks

### DIFF
--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -242,7 +242,7 @@ def new_host(
     peerstore_opt: Optional[IPeerStore] = None,
     disc_opt: Optional[IPeerRouting] = None,
     muxer_preference: Optional[Literal["YAMUX", "MPLEX"]] = None,
-    listen_addrs: Sequence[multiaddr.Multiaddr] = None,
+    listen_addrs: Optional[Sequence[multiaddr.Multiaddr]] = None,
 ) -> IHost:
     """
     Create a new libp2p host based on the given parameters.

--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncContextManager,
+    Optional,
 )
 
 from multiaddr import (
@@ -273,7 +274,7 @@ class INetStream(ReadWriteCloser):
     muxed_conn: IMuxedConn
 
     @abstractmethod
-    def get_protocol(self) -> TProtocol:
+    def get_protocol(self) -> Optional[TProtocol]:
         """
         Retrieve the protocol identifier for the stream.
 
@@ -1550,7 +1551,7 @@ class IMultiselectMuxer(ABC):
     and its corresponding handler for communication.
     """
 
-    handlers: dict[TProtocol, StreamHandlerFn]
+    handlers: dict[Optional[TProtocol], Optional[StreamHandlerFn]]
 
     @abstractmethod
     def add_handler(self, protocol: TProtocol, handler: StreamHandlerFn) -> None:
@@ -1566,7 +1567,7 @@ class IMultiselectMuxer(ABC):
 
         """
 
-    def get_protocols(self) -> tuple[TProtocol, ...]:
+    def get_protocols(self) -> tuple[Optional[TProtocol], ...]:
         """
         Retrieve the protocols for which handlers have been registered.
 
@@ -1581,7 +1582,7 @@ class IMultiselectMuxer(ABC):
     @abstractmethod
     async def negotiate(
         self, communicator: IMultiselectCommunicator
-    ) -> tuple[TProtocol, StreamHandlerFn]:
+    ) -> tuple[Optional[TProtocol], Optional[StreamHandlerFn]]:
         """
         Negotiate a protocol selection with a multiselect client.
 
@@ -1856,7 +1857,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def add_peer(self, peer_id: ID, protocol_id: TProtocol) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: Optional[TProtocol]) -> None:
         """
         Notify the router that a new peer has connected.
 

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -95,7 +95,7 @@ class BasicHost(IHost):
         self.peerstore = self._network.peerstore
         # Protocol muxing
         default_protocols = default_protocols or get_default_protocols(self)
-        self.multiselect = Multiselect(default_protocols)
+        self.multiselect = Multiselect(dict(default_protocols.items()))
         self.multiselect_client = MultiselectClient()
 
     def get_id(self) -> ID:
@@ -235,6 +235,15 @@ class BasicHost(IHost):
             await net_stream.reset()
             return
         net_stream.set_protocol(protocol)
+        if handler is None:
+            logger.debug(
+                "no handler for protocol %s, closing stream from peer %s",
+                protocol,
+                net_stream.muxed_conn.peer_id,
+            )
+            await net_stream.reset()
+            return
+
         await handler(net_stream)
 
     def get_live_peers(self) -> list[ID]:

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -35,7 +35,7 @@ class NetStream(INetStream):
         self.muxed_conn = muxed_stream.muxed_conn
         self.protocol_id = None
 
-    def get_protocol(self) -> TProtocol:
+    def get_protocol(self) -> Optional[TProtocol]:
         """
         :return: protocol id that stream runs on
         """

--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -3,6 +3,7 @@ from collections.abc import (
 )
 from typing import (
     Any,
+    Optional,
 )
 
 from multiaddr import (
@@ -19,8 +20,8 @@ from libp2p.crypto.keys import (
 
 
 class PeerData(IPeerData):
-    pubkey: PublicKey
-    privkey: PrivateKey
+    pubkey: Optional[PublicKey]
+    privkey: Optional[PrivateKey]
     metadata: dict[Any, Any]
     protocols: list[str]
     addrs: list[Multiaddr]

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from libp2p.abc import (
     IMultiselectCommunicator,
     IMultiselectMuxer,
@@ -23,16 +25,21 @@ class Multiselect(IMultiselectMuxer):
     communication.
     """
 
-    handlers: dict[TProtocol, StreamHandlerFn]
+    handlers: dict[Optional[TProtocol], Optional[StreamHandlerFn]]
 
     def __init__(
-        self, default_handlers: dict[TProtocol, StreamHandlerFn] = None
+        self,
+        default_handlers: Optional[
+            dict[Optional[TProtocol], Optional[StreamHandlerFn]]
+        ] = None,
     ) -> None:
         if not default_handlers:
             default_handlers = {}
         self.handlers = default_handlers
 
-    def add_handler(self, protocol: TProtocol, handler: StreamHandlerFn) -> None:
+    def add_handler(
+        self, protocol: Optional[TProtocol], handler: Optional[StreamHandlerFn]
+    ) -> None:
         """
         Store the handler with the given protocol.
 
@@ -41,9 +48,10 @@ class Multiselect(IMultiselectMuxer):
         """
         self.handlers[protocol] = handler
 
+    # FIXME: Make TProtocol Optional[TProtocol] to keep types consistent
     async def negotiate(
         self, communicator: IMultiselectCommunicator
-    ) -> tuple[TProtocol, StreamHandlerFn]:
+    ) -> tuple[TProtocol, Optional[StreamHandlerFn]]:
         """
         Negotiate performs protocol selection.
 

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -62,7 +62,7 @@ class FloodSub(IPubsubRouter):
         """
         self.pubsub = pubsub
 
-    def add_peer(self, peer_id: ID, protocol_id: TProtocol) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: Optional[TProtocol]) -> None:
         """
         Notifies the router that a new peer has been connected.
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -173,7 +173,7 @@ class GossipSub(IPubsubRouter, Service):
 
         logger.debug("attached to pusub")
 
-    def add_peer(self, peer_id: ID, protocol_id: TProtocol) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: Optional[TProtocol]) -> None:
         """
         Notifies the router that a new peer has been connected.
 
@@ -181,6 +181,9 @@ class GossipSub(IPubsubRouter, Service):
         :param protocol_id: router protocol the peer speaks, e.g., floodsub, gossipsub
         """
         logger.debug("adding peer %s with protocol %s", peer_id, protocol_id)
+
+        if protocol_id is None:
+            raise ValueError("Protocol cannot be None")
 
         if protocol_id not in (PROTOCOL_ID, floodsub.PROTOCOL_ID):
             # We should never enter here. Becuase the `protocol_id` is registered by

--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -105,7 +105,7 @@ async def run_handshake(
     local_private_key: PrivateKey,
     conn: IRawConnection,
     is_initiator: bool,
-    remote_peer_id: ID,
+    remote_peer_id: Optional[ID],
 ) -> ISecureConn:
     """Raise `HandshakeFailure` when handshake failed."""
     msg = make_exchange_message(local_private_key.get_public_key())

--- a/libp2p/security/secio/transport.py
+++ b/libp2p/security/secio/transport.py
@@ -209,7 +209,8 @@ async def _response_to_msg(read_writer: SecioPacketReadWriter, msg: bytes) -> by
 
 
 def _mk_multihash_sha256(data: bytes) -> bytes:
-    return multihash.digest(data, "sha2-256")
+    mh = multihash.digest(data, "sha2-256")
+    return mh.encode()
 
 
 def _mk_score(public_key: PublicKey, nonce: bytes) -> bytes:
@@ -395,7 +396,7 @@ async def create_secure_session(
     local_peer: PeerID,
     local_private_key: PrivateKey,
     conn: IRawConnection,
-    remote_peer: PeerID = None,
+    remote_peer: Optional[PeerID] = None,
 ) -> ISecureConn:
     """
     Attempt the initial `secio` handshake with the remote peer.

--- a/libp2p/security/secure_session.py
+++ b/libp2p/security/secure_session.py
@@ -53,7 +53,7 @@ class SecureSession(BaseSession):
         self.low_watermark = 0
         self.high_watermark = 0
 
-    def _drain(self, n: int) -> bytes:
+    def _drain(self, n: Optional[int]) -> bytes:
         if self.low_watermark == self.high_watermark:
             return b""
 
@@ -84,6 +84,10 @@ class SecureSession(BaseSession):
             return data_from_buffer
 
         msg = await self.conn.read_msg()
+
+        # FIXME: I am not very sure of this fix
+        if n is None:
+            return msg
 
         if n < len(msg):
             self._fill(msg)

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -38,8 +38,8 @@ class MplexStream(IMuxedStream):
     name: str
     stream_id: StreamID
     muxed_conn: "Mplex"
-    read_deadline: int
-    write_deadline: int
+    read_deadline: Optional[int]
+    write_deadline: Optional[int]
 
     # TODO: Add lock for read/write to avoid interleaving receiving messages?
     close_lock: trio.Lock
@@ -68,7 +68,10 @@ class MplexStream(IMuxedStream):
         """
         self.name = name
         self.stream_id = stream_id
-        self.muxed_conn = muxed_conn
+        # NOTE: All methods used here are part of `Mplex` which is a derived
+        # class of IMuxedConn. Ignoring this type assignment should not pose
+        # any risk.
+        self.muxed_conn = muxed_conn  # type: ignore[assignment]
         self.read_deadline = None
         self.write_deadline = None
         self.event_local_closed = trio.Event()

--- a/libp2p/stream_muxer/muxer_multistream.py
+++ b/libp2p/stream_muxer/muxer_multistream.py
@@ -95,7 +95,7 @@ class MuxerMultistream:
         if protocol == PROTOCOL_ID:
             async with trio.open_nursery():
 
-                def on_close() -> None:
+                async def on_close() -> None:
                     pass
 
                 return Yamux(

--- a/libp2p/stream_muxer/yamux/yamux.py
+++ b/libp2p/stream_muxer/yamux/yamux.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 import struct
 from typing import (
+    Any,
     Callable,
     Optional,
 )
@@ -126,7 +127,7 @@ class YamuxStream(IMuxedStream):
             )
             await self.conn.secured_conn.write(header)
 
-    async def read(self, n: int = -1) -> bytes:
+    async def read(self, n: Optional[int] = -1) -> bytes:
         # Handle None value for n by converting it to -1
         if n is None:
             n = -1
@@ -253,7 +254,7 @@ class Yamux(IMuxedConn):
         secured_conn: ISecureConn,
         peer_id: ID,
         is_initiator: Optional[bool] = None,
-        on_close: Optional[Callable[[], Awaitable[None]]] = None,
+        on_close: Optional[Callable[[], Awaitable[Any]]] = None,
     ) -> None:
         self.secured_conn = secured_conn
         self.peer_id = peer_id

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -3,6 +3,7 @@ from collections.abc import (
 )
 from typing import (
     NamedTuple,
+    Optional,
 )
 
 import multiaddr
@@ -32,7 +33,7 @@ class GossipsubParams(NamedTuple):
     degree: int = 10
     degree_low: int = 9
     degree_high: int = 11
-    direct_peers: Sequence[PeerInfo] = None
+    direct_peers: Optional[Sequence[PeerInfo]] = None
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5


### PR DESCRIPTION
## What was wrong?
I was not able to add more commits due to pre-commit checks failing.

Issue [#618](https://github.com/libp2p/py-libp2p/pull/618)

## How was it fixed?
I went through all the failing lines of code and fixed them. I have also left FIXMEs in places where I have issues deciding on what to do and have also type ignored one location and left a note explaining why I did it. 

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)
