### PR TITLE
Fix: fixed more-type checks in crypto and peer_data files

### DIFF
--- a/libp2p/crypto/authenticated_encryption.py
+++ b/libp2p/crypto/authenticated_encryption.py
@@ -116,15 +116,15 @@ def initialize_pair(
         EncryptionParameters(
             cipher_type,
             hash_type,
-            first_half[0:iv_size],
-            first_half[iv_size + cipher_key_size :],
-            first_half[iv_size : iv_size + cipher_key_size],
+            bytes(first_half[0:iv_size]),
+            bytes(first_half[iv_size + cipher_key_size :]),
+            bytes(first_half[iv_size : iv_size + cipher_key_size]),
         ),
         EncryptionParameters(
             cipher_type,
             hash_type,
-            second_half[0:iv_size],
-            second_half[iv_size + cipher_key_size :],
-            second_half[iv_size : iv_size + cipher_key_size],
+            bytes(second_half[0:iv_size]),
+            bytes(second_half[iv_size + cipher_key_size :]),
+            bytes(second_half[iv_size : iv_size + cipher_key_size]),
         ),
     )

--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -1,9 +1,7 @@
 from collections.abc import (
     Sequence,
 )
-from typing import (
-    Any,
-)
+from typing import Any, Union
 
 from multiaddr import (
     Multiaddr,
@@ -19,8 +17,8 @@ from libp2p.crypto.keys import (
 
 
 class PeerData(IPeerData):
-    pubkey: PublicKey
-    privkey: PrivateKey
+    pubkey: Union[PublicKey, None]
+    privkey: Union[PrivateKey, None]
     metadata: dict[Any, Any]
     protocols: list[str]
     addrs: list[Multiaddr]

--- a/tests/core/peer/test_peerdata.py
+++ b/tests/core/peer/test_peerdata.py
@@ -1,4 +1,7 @@
+from collections.abc import Sequence
+
 import pytest
+from multiaddr import Multiaddr
 
 from libp2p.crypto.secp256k1 import (
     create_new_key_pair,
@@ -8,7 +11,7 @@ from libp2p.peer.peerdata import (
     PeerDataError,
 )
 
-MOCK_ADDR = "/peer"
+MOCK_ADDR = Multiaddr("/ip4/127.0.0.1/tcp/4001")
 MOCK_KEYPAIR = create_new_key_pair()
 MOCK_PUBKEY = MOCK_KEYPAIR.public_key
 MOCK_PRIVKEY = MOCK_KEYPAIR.private_key
@@ -23,7 +26,7 @@ def test_get_protocols_empty():
 # Test case when adding protocols
 def test_add_protocols():
     peer_data = PeerData()
-    protocols = ["protocol1", "protocol2"]
+    protocols: Sequence[str] = ["protocol1", "protocol2"]
     peer_data.add_protocols(protocols)
     assert peer_data.get_protocols() == protocols
 
@@ -31,7 +34,7 @@ def test_add_protocols():
 # Test case when setting protocols
 def test_set_protocols():
     peer_data = PeerData()
-    protocols = ["protocolA", "protocolB"]
+    protocols: Sequence[str] = ["protocol1", "protocol2"]
     peer_data.set_protocols(protocols)
     assert peer_data.get_protocols() == protocols
 
@@ -39,7 +42,7 @@ def test_set_protocols():
 # Test case when adding addresses
 def test_add_addrs():
     peer_data = PeerData()
-    addresses = [MOCK_ADDR]
+    addresses: Sequence[Multiaddr] = [MOCK_ADDR]
     peer_data.add_addrs(addresses)
     assert peer_data.get_addrs() == addresses
 
@@ -47,7 +50,7 @@ def test_add_addrs():
 # Test case when adding same address more than once
 def test_add_dup_addrs():
     peer_data = PeerData()
-    addresses = [MOCK_ADDR, MOCK_ADDR]
+    addresses: Sequence[Multiaddr] = [MOCK_ADDR, MOCK_ADDR]
     peer_data.add_addrs(addresses)
     peer_data.add_addrs(addresses)
     assert peer_data.get_addrs() == [MOCK_ADDR]
@@ -56,7 +59,7 @@ def test_add_dup_addrs():
 # Test case for clearing addresses
 def test_clear_addrs():
     peer_data = PeerData()
-    addresses = [MOCK_ADDR]
+    addresses: Sequence[Multiaddr] = [MOCK_ADDR]
     peer_data.add_addrs(addresses)
     peer_data.clear_addrs()
     assert peer_data.get_addrs() == []


### PR DESCRIPTION
## What was wrong?
Issue: https://github.com/libp2p/py-libp2p/pull/618
- In `authenticated_encryption.py`,in `EncryptionParameters` class arguments of type `bytearray`(mutable) was provided in place of `bytes`(immutable).
- In `peer_data.py`,`PeerData` class during instantiation was assigning `None` value to `pubKey` which is of type `PublicKey`,causing type-error.Same for `privKey`.
- In `test_peerdata`,list of `Multiaddr` & `Protocols` was being passed instead of expected `Sequence`.Also,erroneous dummy-address was used for Multiaddr, raising invalid protocol error.   

## How was it fixed?
  - Encapsulated `bytearray` in `bytes` class,when passing into `EncryptionParameters` class.
  - Changed type of `pubKey` and `privKey` to `Union[key,None]`,allowing None to be assigned during `init` . 
  - Changed MOCK_ADDR to a `MultiAddr` class object with a valid dummy-address.Done Type-conversion in protocols and addresses from `list` to `Sequence`


### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal image](https://compote.slate.com/images/73f0857e-2a1a-4fea-b97a-bd4c241c01f5.jpg)
