### PR TITLE
Fix: Typefix at peerinfo and interop-utils

### DIFF
--- a/libp2p/peer/peerinfo.py
+++ b/libp2p/peer/peerinfo.py
@@ -46,7 +46,10 @@ def info_from_p2p_addr(addr: multiaddr.Multiaddr) -> PeerInfo:
         )
 
     # make sure the /p2p value parses as a peer.ID
-    peer_id_str: str = p2p_part.value_for_protocol(multiaddr.multiaddr.protocols.P_P2P)
+    peer_id_str = p2p_part.value_for_protocol(multiaddr.multiaddr.protocols.P_P2P)
+    if peer_id_str is None:
+        raise InvalidAddrError("Missing value for /p2p protocol in multiaddr")
+
     peer_id: ID = ID.from_base58(peer_id_str)
 
     # we might have received just an / p2p part, which means there's no addr.

--- a/tests/utils/interop/utils.py
+++ b/tests/utils/interop/utils.py
@@ -5,6 +5,7 @@ from typing import (
 from multiaddr import (
     Multiaddr,
 )
+from p2pclient.libp2p_stubs.peer.id import ID as StubID
 import trio
 
 from libp2p.abc import IHost
@@ -56,7 +57,10 @@ async def connect(a: TDaemonOrHost, b: TDaemonOrHost) -> None:
 
     b_peer_info = _get_peer_info(b)
     if isinstance(a, Daemon):
-        await a.control.connect(b_peer_info.peer_id, b_peer_info.addrs)
+        # Convert internal libp2p ID to p2pclient stub ID .connect()
+        await a.control.connect(
+            StubID(b_peer_info.peer_id.to_bytes()), b_peer_info.addrs
+        )
     else:  # isinstance(b, IHost)
         await a.connect(b_peer_info)
     # Allow additional sleep for both side to establish the connection.


### PR DESCRIPTION
Fixed 2 type errors:
1. `libp2p/peer/peerinfo.py`: Added runtime check to ensure `value_for_protocol()` does not return `None` before assigning it to `str`-typed variable. This resolves a Pyright type error `(Unknown | Any | None not assignable to str)` and prevents potention runtime issues if the `/p2p` component is missing from the multiaddr

2. `tests/utils/interop/utils.py`: This resolves:
```bash
Argument of type "ID" cannot be assigned to parameter "peer_id" of type "ID" in function "connect"
"libp2p.peer.id.ID" is not assignable to "p2pclient.libp2p_stubs.peer.id.ID"
```
Fixed by converting `b_peer_info.peer_id` to the correct stub type via `to_bytes()` and wrapping it in `StubId`