### PR TITLE
fix: ensure initiator user includes remote peer id in handshake

### DIFF
--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -124,6 +124,15 @@ async def run_handshake(
     remote_msg.ParseFromString(remote_msg_bytes)
     received_peer_id = ID(remote_msg.id)
 
+    # Verify that `remote_peer_id` isn't `None`
+    # That is the only condition that `remote_peer_id` would not need to be checked
+    # against the `recieved_peer_id` gotten from the outbound/recieved `msg`.
+    # The check against `received_peer_id` happens in the next if-block
+    if is_initiator and not remote_peer_id:
+        raise HandshakeFailure(
+            "remote peer ID cannot be None if `is_initiator` is set to `True`"
+        )
+
     # Verify if the receive `ID` matches the one we originally initialize the session.
     # We only need to check it when we are the initiator, because only in that condition
     # we possibly knows the `ID` of the remote.


### PR DESCRIPTION
## What was wrong?

Error handling is absent for when [optional parameter `remote_peer_id`](https://github.com/arcinston/py-libp2p/blob/99c8cf7a350911026809a74be5d2349c92df0e11/libp2p/security/insecure/transport.py#L108) is set to `None` for an initiator host.

Issue #

## How was it fixed?
A comprehensive `HandshakeFailure` exception is returned if the host is initiator (i.e `is_initiator` is True) and `remote_peer_id` is `None`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/474x/c2/83/92/c28392b8722c02339470f51b5eb30965.jpg)
