### PR TITLE
Typefix: `test_peerinfo.py` and `custom_types.py`

### DIFF
--- a/libp2p/custom_types.py
+++ b/libp2p/custom_types.py
@@ -2,12 +2,7 @@ from collections.abc import (
     Awaitable,
     Mapping,
 )
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    NewType,
-    Union,
-)
+from typing import TYPE_CHECKING, Callable, NewType, Union, cast
 
 if TYPE_CHECKING:
     from libp2p.abc import (
@@ -16,15 +11,9 @@ if TYPE_CHECKING:
         ISecureTransport,
     )
 else:
-
-    class INetStream:
-        pass
-
-    class IMuxedConn:
-        pass
-
-    class ISecureTransport:
-        pass
+    IMuxedConn = cast(type, object)
+    INetStream = cast(type, object)
+    ISecureTransport = cast(type, object)
 
 
 from libp2p.io.abc import (
@@ -38,10 +27,10 @@ from libp2p.pubsub.pb import (
 )
 
 TProtocol = NewType("TProtocol", str)
-StreamHandlerFn = Callable[["INetStream"], Awaitable[None]]
+StreamHandlerFn = Callable[[INetStream], Awaitable[None]]
 THandler = Callable[[ReadWriteCloser], Awaitable[None]]
-TSecurityOptions = Mapping[TProtocol, "ISecureTransport"]
-TMuxerClass = type["IMuxedConn"]
+TSecurityOptions = Mapping[TProtocol, ISecureTransport]
+TMuxerClass = type[IMuxedConn]
 TMuxerOptions = Mapping[TProtocol, TMuxerClass]
 SyncValidatorFn = Callable[[ID, rpc_pb2.Message], bool]
 AsyncValidatorFn = Callable[[ID, rpc_pb2.Message], Awaitable[bool]]

--- a/libp2p/io/abc.py
+++ b/libp2p/io/abc.py
@@ -2,9 +2,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from typing import (
-    Optional,
-)
+from typing import Any, Optional
 
 
 class Closer(ABC):
@@ -70,8 +68,17 @@ class Encrypter(ABC):
 class EncryptedMsgReadWriter(MsgReadWriteCloser, Encrypter):
     """Read/write message with encryption/decryption."""
 
+    conn: Optional[Any]
+
+    def __init__(self, conn: Optional[Any] = None):
+        self.conn = conn
+
     def get_remote_address(self) -> Optional[tuple[str, int]]:
         """Get remote address if supported by the underlying connection."""
-        if hasattr(self, "conn") and hasattr(self.conn, "get_remote_address"):
+        if (
+            self.conn is not None
+            and hasattr(self, "conn")
+            and hasattr(self.conn, "get_remote_address")
+        ):
             return self.conn.get_remote_address()
         return None

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -90,6 +90,8 @@ class Multiselect(IMultiselectMuxer):
                 except MultiselectCommunicatorError as error:
                     raise MultiselectError() from error
 
+        raise MultiselectError("Negotiation failed: no matching protocol")
+
     async def handshake(self, communicator: IMultiselectCommunicator) -> None:
         """
         Perform handshake to agree on multiselect protocol.

--- a/tests/core/peer/test_peerinfo.py
+++ b/tests/core/peer/test_peerinfo.py
@@ -17,10 +17,14 @@ VALID_MULTI_ADDR_STR = "/ip4/127.0.0.1/tcp/8000/p2p/3YgLAeMKSAPcGqZkAt8mREqhQXmJ
 
 
 def test_init_():
-    random_addrs = [random.randint(0, 255) for r in range(4)]
+    random_addrs = [
+        multiaddr.Multiaddr(f"/ip4/127.0.0.1/tcp/{1000 + i}") for i in range(4)
+    ]
+
     random_id_string = ""
     for _ in range(10):
         random_id_string += random.SystemRandom().choice(ALPHABETS)
+
     peer_id = ID(random_id_string.encode())
     peer_info = PeerInfo(peer_id, random_addrs)
 


### PR DESCRIPTION
13 typefixes in these. Now remain 98 at my end
1. `libp2p/custom_types.py`
2. `tests/core/peer/test_peerinfo.py`
3. `libp2p/io/abc.py`
4. `libp2p/pubsub/floodsub.py`
5. `libp2p/protocol_muxer/multiselect.py`