### PR TITLE
fix: Typefixes in PeerInfo 

### DIFF
--- a/libp2p/peer/peerinfo.py
+++ b/libp2p/peer/peerinfo.py
@@ -39,7 +39,14 @@ def info_from_p2p_addr(addr: multiaddr.Multiaddr) -> PeerInfo:
         )
 
     p2p_part = parts[-1]
-    last_protocol_code = p2p_part.protocols()[0].code
+    p2p_protocols = p2p_part.protocols()
+    if not p2p_protocols:
+        raise InvalidAddrError("The last part of the address has no protocols")
+    last_protocol = p2p_protocols[0]
+    if last_protocol is None:
+        raise InvalidAddrError("The last protocol is None")
+
+    last_protocol_code = last_protocol.code
     if last_protocol_code != multiaddr.multiaddr.protocols.P_P2P:
         raise InvalidAddrError(
             f"The last protocol should be `P_P2P` instead of `{last_protocol_code}`"

--- a/tests/core/stream_muxer/test_yamux.py
+++ b/tests/core/stream_muxer/test_yamux.py
@@ -215,8 +215,14 @@ async def test_yamux_stream_reset(yamux_pair):
     server_stream = await server_yamux.accept_stream()
     await client_stream.reset()
     # After reset, reading should raise MuxedStreamReset or MuxedStreamEOF
-    with pytest.raises((MuxedStreamEOF, MuxedStreamError)):
+    # with pytest.raises((MuxedStreamEOF, MuxedStreamError)):
+    #     await server_stream.read()
+    try:
         await server_stream.read()
+    except (MuxedStreamEOF, MuxedStreamError):
+        pass
+    else:
+        pytest.fail("Expected MuxedStreamEOF or MuxedStreamError")
     # Verify subsequent operations fail with StreamReset or EOF
     with pytest.raises(MuxedStreamError):
         await server_stream.read()

--- a/tests/utils/pubsub/dummy_account_node.py
+++ b/tests/utils/pubsub/dummy_account_node.py
@@ -5,9 +5,11 @@ from contextlib import (
     AsyncExitStack,
     asynccontextmanager,
 )
+from typing import Optional
 
 from libp2p.abc import (
     IHost,
+    ISubscriptionAPI,
 )
 from libp2p.pubsub.pubsub import (
     Pubsub,
@@ -40,9 +42,11 @@ class DummyAccountNode(Service):
     """
 
     pubsub: Pubsub
+    subscription: Optional[ISubscriptionAPI]
 
     def __init__(self, pubsub: Pubsub) -> None:
         self.pubsub = pubsub
+        self.subscription = None
         self.balances: dict[str, int] = {}
 
     @property
@@ -74,6 +78,10 @@ class DummyAccountNode(Service):
     async def handle_incoming_msgs(self) -> None:
         """Handle all incoming messages on the CRYPTO_TOPIC from peers."""
         while True:
+            if self.subscription is None:
+                raise RuntimeError(
+                    "Subscription must be set before handling incoming messages"
+                )
             incoming = await self.subscription.get()
             msg_comps = incoming.data.decode("utf-8").split(",")
 


### PR DESCRIPTION
16 typefixes in:
1. `libp2p/peer/peer_info.py`
2. `tests/utils/pubsub/dumm_accouunt_node.py`
3. `tests/utils/factories.py`
4. `tests/core/stream_muxer/test_yamux.py`