### PR TITLE
fix: Minor typefixes in tests

### DIFF
--- a/libp2p/crypto/ecc.py
+++ b/libp2p/crypto/ecc.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Union
 
 from libp2p.crypto.keys import (
     KeyPair,
@@ -25,6 +24,7 @@ else:
 
 
 if sys.platform != "win32":
+
     def infer_local_type(curve: str) -> curve_types.Curve:
         """
         Convert a str representation of some elliptic curve to a
@@ -34,6 +34,7 @@ if sys.platform != "win32":
             raise NotImplementedError("Only P-256 curve is supported")
         return curve_types.P256
 else:
+
     def infer_local_type(curve: str) -> str:
         """
         Convert a str representation of some elliptic curve to a

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -149,17 +149,6 @@ async def test_set_and_remove_topic_validator():
         topic_validator = pubsubs_fsub[0].topic_validators[topic]
         assert not topic_validator.is_async
 
-        topic_1 = "TEST_VALIDATOR_1"
-        topic_2 = "TEST_VALIDATOR_2"
-        topic_3 = "TEST_VALIDATOR_3"
-
-        msg = make_pubsub_msg(
-            origin_id=pubsubs_fsub[0].my_id,
-            topic_ids=[topic_1, topic_2, topic_3],
-            data=b"1234",
-            seqno=b"\x00" * 8,
-        )
-
         # Validate with sync validator
         test_msg = make_pubsub_msg(
             origin_id=IDFactory(),

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -149,6 +149,17 @@ async def test_set_and_remove_topic_validator():
         topic_validator = pubsubs_fsub[0].topic_validators[topic]
         assert not topic_validator.is_async
 
+        topic_1 = "TEST_VALIDATOR_1"
+        topic_2 = "TEST_VALIDATOR_2"
+        topic_3 = "TEST_VALIDATOR_3"
+
+        msg = make_pubsub_msg(
+            origin_id=pubsubs_fsub[0].my_id,
+            topic_ids=[topic_1, topic_2, topic_3],
+            data=b"1234",
+            seqno=b"\x00" * 8,
+        )
+
         # Validate with sync validator
         test_msg = make_pubsub_msg(
             origin_id=IDFactory(),

--- a/tests/core/stream_muxer/test_multiplexer_selection.py
+++ b/tests/core/stream_muxer/test_multiplexer_selection.py
@@ -13,6 +13,7 @@ from libp2p import (
     set_default_muxer,
 )
 from libp2p.custom_types import TProtocol
+from libp2p.peer.peerinfo import PeerInfo
 
 # Enable logging for debugging
 logging.basicConfig(level=logging.DEBUG)
@@ -32,7 +33,8 @@ async def host_pair(muxer_preference=None, muxer_opt=None):
     # Connect hosts with a timeout
     listen_addrs_a = host_a.get_addrs()
     with trio.move_on_after(5):  # 5 second timeout
-        await host_b.connect(host_a.get_id(), listen_addrs_a)
+        peer_info_a = PeerInfo(host_a.get_id(), listen_addrs_a)
+        await host_b.connect(peer_info_a)
 
     yield host_a, host_b
 
@@ -65,8 +67,8 @@ async def test_multiplexer_preference_parameter(muxer_preference):
             # Connect hosts with timeout
             listen_addrs_a = host_a.get_addrs()
             with trio.move_on_after(5):  # 5 second timeout
-                await host_b.connect(host_a.get_id(), listen_addrs_a)
-
+                peer_info_a = PeerInfo(host_a.get_id(), listen_addrs_a)
+                await host_b.connect(peer_info_a)
             # Check if connection was established
             connections = host_b.get_network().connections
             assert len(connections) > 0, "Connection not established"
@@ -140,7 +142,8 @@ async def test_explicit_muxer_options(muxer_option_func, expected_stream_class):
             # Connect hosts with timeout
             listen_addrs_a = host_a.get_addrs()
             with trio.move_on_after(5):  # 5 second timeout
-                await host_b.connect(host_a.get_id(), listen_addrs_a)
+                peer_info_a = PeerInfo(host_a.get_id(), listen_addrs_a)
+                await host_b.connect(peer_info_a)
 
             # Check if connection was established
             connections = host_b.get_network().connections
@@ -208,7 +211,8 @@ async def test_global_default_muxer(global_default):
             # Connect hosts with timeout
             listen_addrs_a = host_a.get_addrs()
             with trio.move_on_after(5):  # 5 second timeout
-                await host_b.connect(host_a.get_id(), listen_addrs_a)
+                peer_info_a = PeerInfo(host_a.get_id(), listen_addrs_a)
+                await host_b.connect(peer_info_a)
 
             # Check if connection was established
             connections = host_b.get_network().connections

--- a/tests/stream_muxer/test_async_context_manager.py
+++ b/tests/stream_muxer/test_async_context_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Optional
 
 import pytest
 import trio
@@ -180,7 +180,7 @@ async def test_mplex_stream_async_context_manager_write_after_close():
 
 @pytest.mark.trio
 async def test_yamux_stream_async_context_manager_write_after_close():
-    muxed_conn = cast(Yamux, MockMuxedConn())
+    muxed_conn = Yamux(DummySecuredConn(), DUMMY_PEER_ID)
     stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
     async with stream as s:
         assert s is stream

--- a/tests/stream_muxer/test_async_context_manager.py
+++ b/tests/stream_muxer/test_async_context_manager.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 import trio
 
@@ -8,17 +10,31 @@ from libp2p.stream_muxer.exceptions import (
 from libp2p.stream_muxer.mplex.datastructures import (
     StreamID,
 )
+from libp2p.stream_muxer.mplex.mplex import Mplex
 from libp2p.stream_muxer.mplex.mplex_stream import (
     MplexStream,
 )
 from libp2p.stream_muxer.yamux.yamux import (
+    Yamux,
     YamuxStream,
 )
 
 
 class DummySecuredConn:
-    async def write(self, data):
+    async def write(self, data: bytes) -> None:
         pass
+
+    async def read(self, n: int) -> bytes:
+        return b""
+
+    async def close(self) -> None:
+        pass
+
+    def get_remote_address(self):
+        return None
+
+    def get_local_address(self):
+        return None
 
 
 class MockMuxedConn:
@@ -39,7 +55,7 @@ class MockMuxedConn:
 
 @pytest.mark.trio
 async def test_mplex_stream_async_context_manager():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Mplex, MockMuxedConn())
     stream_id = StreamID(1, True)  # Use real StreamID
     stream = MplexStream(
         name="test_stream",
@@ -57,7 +73,7 @@ async def test_mplex_stream_async_context_manager():
 
 @pytest.mark.trio
 async def test_yamux_stream_async_context_manager():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Yamux, MockMuxedConn())
     stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
     async with stream as s:
         assert s is stream
@@ -69,7 +85,7 @@ async def test_yamux_stream_async_context_manager():
 
 @pytest.mark.trio
 async def test_mplex_stream_async_context_manager_with_error():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Mplex, MockMuxedConn())
     stream_id = StreamID(1, True)
     stream = MplexStream(
         name="test_stream",
@@ -89,7 +105,7 @@ async def test_mplex_stream_async_context_manager_with_error():
 
 @pytest.mark.trio
 async def test_yamux_stream_async_context_manager_with_error():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Yamux, MockMuxedConn())
     stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
     with pytest.raises(ValueError):
         async with stream as s:
@@ -103,7 +119,7 @@ async def test_yamux_stream_async_context_manager_with_error():
 
 @pytest.mark.trio
 async def test_mplex_stream_async_context_manager_write_after_close():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Mplex, MockMuxedConn())
     stream_id = StreamID(1, True)
     stream = MplexStream(
         name="test_stream",
@@ -119,7 +135,7 @@ async def test_mplex_stream_async_context_manager_write_after_close():
 
 @pytest.mark.trio
 async def test_yamux_stream_async_context_manager_write_after_close():
-    muxed_conn = MockMuxedConn()
+    muxed_conn = cast(Yamux, MockMuxedConn())
     stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
     async with stream as s:
         assert s is stream


### PR DESCRIPTION
41 errors remain, 44 fixed in:
1. `tests/stream_muxer/test_async_context_manager.py`
2. `tests/core/stream_muxer/test_multiplexer_selection.py`
3. `tests/core/pubsub/test_pubsub.py`