### PR TITLE
fix: add connection state for net stream and gracefully handle failure

### DIFF
--- a/libp2p/crypto/ecc.py
+++ b/libp2p/crypto/ecc.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Union
 
 from libp2p.crypto.keys import (
     KeyPair,
@@ -25,6 +24,7 @@ else:
 
 
 if sys.platform != "win32":
+
     def infer_local_type(curve: str) -> curve_types.Curve:
         """
         Convert a str representation of some elliptic curve to a
@@ -34,6 +34,7 @@ if sys.platform != "win32":
             raise NotImplementedError("Only P-256 curve is supported")
         return curve_types.P256
 else:
+
     def infer_local_type(curve: str) -> str:
         """
         Convert a str representation of some elliptic curve to a

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -1,6 +1,7 @@
-from typing import (
-    Optional,
-)
+from enum import Enum
+from typing import Optional
+
+import trio
 
 from libp2p.abc import (
     IMuxedStream,
@@ -23,17 +24,38 @@ from .exceptions import (
 )
 
 
-# TODO: Handle exceptions from `muxed_stream`
-# TODO: Add stream state
-#   - Reference: https://github.com/libp2p/go-libp2p-swarm/blob/99831444e78c8f23c9335c17d8f7c700ba25ca14/swarm_stream.go  # noqa: E501
+class StreamState(Enum):
+    """NetStream States"""
+
+    OPEN = "open"
+    CLOSE_READ = "close_read"
+    CLOSE_WRITE = "close_write"
+    CLOSE_BOTH = "close_both"
+    RESET = "reset"
+
+
 class NetStream(INetStream):
+    """Class representing NetStream Handler"""
+
     muxed_stream: IMuxedStream
     protocol_id: Optional[TProtocol]
 
-    def __init__(self, muxed_stream: IMuxedStream) -> None:
+    def __init__(
+        self, muxed_stream: IMuxedStream, nursery: Optional[trio.Nursery] = None
+    ) -> None:
+        super().__init__()
+
         self.muxed_stream = muxed_stream
         self.muxed_conn = muxed_stream.muxed_conn
         self.protocol_id = None
+        self._nursery = nursery  # For background tasks
+
+        # State management
+        self._state = StreamState.OPEN
+        self._state_lock = trio.Lock()
+
+        # For notification handling
+        self._notify_lock = trio.Lock()
 
     def get_protocol(self) -> Optional[TProtocol]:
         """
@@ -47,6 +69,12 @@ class NetStream(INetStream):
         """
         self.protocol_id = protocol_id
 
+    @property
+    async def state(self) -> StreamState:
+        """Get current stream state."""
+        async with self._state_lock:
+            return self._state
+
     async def read(self, n: Optional[int] = None) -> bytes:
         """
         Read from stream.
@@ -54,35 +82,153 @@ class NetStream(INetStream):
         :param n: number of bytes to read
         :return: bytes of input
         """
+        async with self._state_lock:
+            if self._state in [
+                StreamState.CLOSE_READ,
+                StreamState.CLOSE_BOTH,
+                StreamState.RESET,
+            ]:
+                raise StreamClosed("Stream is closed for reading")
+
         try:
-            return await self.muxed_stream.read(n)
+            data = await self.muxed_stream.read(n)
+            return data
         except MuxedStreamEOF as error:
+            async with self._state_lock:
+                if self._state == StreamState.CLOSE_WRITE:
+                    self._state = StreamState.CLOSE_BOTH
+                    await self._remove()
+                elif self._state == StreamState.OPEN:
+                    self._state = StreamState.CLOSE_READ
             raise StreamEOF() from error
         except MuxedStreamReset as error:
+            async with self._state_lock:
+                if self._state in [
+                    StreamState.OPEN,
+                    StreamState.CLOSE_READ,
+                    StreamState.CLOSE_WRITE,
+                ]:
+                    self._state = StreamState.RESET
+                    await self._remove()
             raise StreamReset() from error
 
     async def write(self, data: bytes) -> None:
         """
         Write to stream.
 
-        :return: number of bytes written
+        :param data: bytes to write
         """
+        async with self._state_lock:
+            if self._state in [
+                StreamState.CLOSE_WRITE,
+                StreamState.CLOSE_BOTH,
+                StreamState.RESET,
+            ]:
+                raise StreamClosed("Stream is closed for writing")
+
         try:
             await self.muxed_stream.write(data)
         except (MuxedStreamClosed, MuxedStreamError) as error:
+            # Update state to reflect that writing failed
+            async with self._state_lock:
+                if self._state == StreamState.OPEN:
+                    self._state = StreamState.CLOSE_WRITE
+                elif self._state == StreamState.CLOSE_READ:
+                    self._state = StreamState.CLOSE_BOTH
+                    await self._remove()
             raise StreamClosed() from error
 
     async def close(self) -> None:
-        """Close stream."""
+        """Close stream for writing."""
+        async with self._state_lock:
+            if self._state in [StreamState.CLOSE_BOTH, StreamState.RESET]:
+                return
+            elif self._state == StreamState.CLOSE_WRITE:
+                return
+
         await self.muxed_stream.close()
 
+        # Update state
+        async with self._state_lock:
+            if self._state == StreamState.CLOSE_READ:
+                self._state = StreamState.CLOSE_BOTH
+                await self._remove()
+            elif self._state == StreamState.OPEN:
+                self._state = StreamState.CLOSE_WRITE
+
     async def reset(self) -> None:
+        """Reset stream, closing both ends."""
+        async with self._state_lock:
+            if self._state == StreamState.RESET:
+                return
+
         await self.muxed_stream.reset()
+
+        # Update state and trigger cleanup
+        async with self._state_lock:
+            if self._state in [
+                StreamState.OPEN,
+                StreamState.CLOSE_READ,
+                StreamState.CLOSE_WRITE,
+            ]:
+                self._state = StreamState.RESET
+                await self._remove()
+
+    async def _remove(self) -> None:
+        """
+        Remove stream from connection and notify listeners.
+        This is called when the stream is fully closed or reset.
+        """
+        if hasattr(self.muxed_conn, "remove_stream"):
+            await self.muxed_conn.remove_stream(self)
+
+        # Notify in background using Trio nursery if available
+        if self._nursery:
+            self._nursery.start_soon(self._notify_closed)
+        else:
+            await self._notify_closed()
+
+    async def _notify_closed(self) -> None:
+        """
+        Notify all listeners that the stream has been closed.
+        This runs in a separate task to avoid blocking the main flow.
+        """
+        async with self._notify_lock:
+            if hasattr(self.muxed_conn, "swarm"):
+                swarm = self.muxed_conn.swarm
+
+                if hasattr(swarm, "notify_all"):
+                    await swarm.notify_all(
+                        lambda notifiee: notifiee.closed_stream(swarm, self)
+                    )
+
+                if hasattr(swarm, "refs") and hasattr(swarm.refs, "done"):
+                    swarm.refs.done()
 
     def get_remote_address(self) -> Optional[tuple[str, int]]:
         """Delegate to the underlying muxed stream."""
         return self.muxed_stream.get_remote_address()
 
-    # TODO: `remove`: Called by close and write when the stream is in specific states.
-    #   It notifies `ClosedStream` after `SwarmConn.remove_stream` is called.
-    # Reference: https://github.com/libp2p/go-libp2p-swarm/blob/99831444e78c8f23c9335c17d8f7c700ba25ca14/swarm_stream.go  # noqa: E501
+    def is_closed(self) -> bool:
+        """Check if stream is closed."""
+        return self.state in [StreamState.CLOSE_BOTH, StreamState.RESET]
+
+    def is_readable(self) -> bool:
+        """Check if stream is readable."""
+        return self.state not in [
+            StreamState.CLOSE_READ,
+            StreamState.CLOSE_BOTH,
+            StreamState.RESET,
+        ]
+
+    def is_writable(self) -> bool:
+        """Check if stream is writable."""
+        return self.state not in [
+            StreamState.CLOSE_WRITE,
+            StreamState.CLOSE_BOTH,
+            StreamState.RESET,
+        ]
+
+    def __str__(self) -> str:
+        """String representation of the stream."""
+        return f"<NetStream[{self.state.value}] protocol={self.protocol_id}>"


### PR DESCRIPTION
## What was wrong?

The Python NetStream class was too simple compared to its Go counterpart. It lacked proper state management and cleanup mechanisms, which meant:

- No way to track if a stream was open, closed for reading/writing, or reset
- No proper cleanup when streams closed (removing from SwarmConn, triggering ClosedStream events)
- No state validation before operations (could attempt to write to write-closed streams)
- Missing notification system for stream lifecycle events

Issue #300

## How was it fixed?

Enhanced NetStream with state management:
1. State Tracking: Added StreamState enum (OPEN, CLOSE_READ, CLOSE_WRITE, CLOSE_BOTH, RESET) with Trio-compatible async locks
2. Operation Validation: Added state checks before read/write/close operations to prevent invalid actions and provide clear error messages
3. Proper Cleanup: Implemented _remove() method that:
   1. Removes stream from swarm connection
   2. Notifies all listeners via ClosedStream events
   3. Handles reference counting
5. State Transitions: Automatic state updates based on:
    - EOF on read → close read side
    - Explicit close → close write side
    - Reset → close both sides
    - Triggers cleanup when fully closed

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)
