### PR TITLE
Fix failing Yamux tests by adding is_initiator to DummySecuredConn

### DIFF
--- a/tests/core/stream_muxer/test_async_context_manager.py
+++ b/tests/core/stream_muxer/test_async_context_manager.py
@@ -26,6 +26,9 @@ DUMMY_PEER_ID = ID(b"dummy_peer_id")
 
 
 class DummySecuredConn(ISecureConn):
+    def __init__(self):
+        self.is_initiator = True
+
     async def write(self, data: bytes) -> None:
         pass
 


### PR DESCRIPTION
## What was wrong?

Failing Yamux Stream Tests

## How was it fixed?

This PR addresses the failure of three tests in `tests/core/stream_muxer/test_async_context_manager.py`:

- `test_yamux_stream_async_context_manager`
- `test_yamux_stream_async_context_manager_with_error`
- `test_yamux_stream_async_context_manager_write_after_close`

The root cause was an `AttributeError: 'DummySecuredConn' object has no attribute 'is_initiator'` during Yamux initialization, as the `DummySecuredConn` mock did not implement the `is_initiator` property expected by the `ISecureConn` interface.
Changes

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1529778873920-4da4926a72c2?q=80&w=1936&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
